### PR TITLE
[Fix] 챌린지 유효기간 필터링 버그 수정

### DIFF
--- a/routers/record/record.py
+++ b/routers/record/record.py
@@ -9,9 +9,7 @@ from services.record import record as record_service
 from auth.jwt_token import get_current_user
 from models import User
 
-
 router = APIRouter(prefix="/records", tags=["records"])
-
 
 @router.post("/create", response_model=RecordsRead)
 def create_records(

--- a/services/challenge/calculate.py
+++ b/services/challenge/calculate.py
@@ -12,7 +12,7 @@ class ChallengeCalculateService:
     def participants_rate(db: Session, challenge: Challenge, participants: List[ChallengeParticipant]
     ) -> List[ChallengeMemberContribution]:
 
-        end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
+        end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7) # 마감일 설정
 
         # 감정 ID 긍정/부정 구분 필터 설정
         positive_emotion_ids = [1, 2, 3]
@@ -28,7 +28,7 @@ class ChallengeCalculateService:
             spend_count = db.query(Record).filter(
                 Record.userId == participant.userId,
                 Record.spendDate >= challenge.createdDate,
-                Record.spendDate < end_date,  # 마감일 미만
+                Record.spendDate < end_date,  
                 emotion_filter
             ).count()
 

--- a/services/challenge/calculate.py
+++ b/services/challenge/calculate.py
@@ -8,14 +8,13 @@ from schemas.challenge import ChallengeMemberContribution, ChallengeTeamProgress
 
 class ChallengeCalculateService:
 
-
     @staticmethod
     def participants_rate(db: Session, challenge: Challenge, participants: List[ChallengeParticipant]
     ) -> List[ChallengeMemberContribution]:
 
-        end_date = challenge.createdDate + timedelta(days=6)
+        end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
 
-        # 감정 ID 긍정/부정 구분 필터 설정
+         # 감정 ID 긍정/부정 구분 필터 설정
         positive_emotion_ids = [1, 2, 3]
         negative_emotion_ids = [4, 5, 6, 7, 8, 9, 10, 11, 12]
         emotion_filter = Record.emotionCategoryId.in_(
@@ -29,7 +28,7 @@ class ChallengeCalculateService:
             spend_count = db.query(Record).filter(
                 Record.userId == participant.userId,
                 Record.spendDate >= challenge.createdDate,
-                Record.spendDate <= end_date,
+                Record.spendDate < end_date,  # 마감일 미만
                 emotion_filter
             ).count()
 
@@ -44,7 +43,7 @@ class ChallengeCalculateService:
                 isHost=participant.isHost,
                 spendCount=spend_count,
                 contributionRate=round(contribution * 100, 1)
-            )   )
+            ))
 
         return result
     
@@ -70,4 +69,4 @@ class ChallengeCalculateService:
         return ChallengeTeamProgress(
             teamProgressRate=round(progress * 100, 1),
             guineaFeedCount=guinea_feed_current
-    )
+        )

--- a/services/challenge/calculate.py
+++ b/services/challenge/calculate.py
@@ -14,7 +14,7 @@ class ChallengeCalculateService:
 
         end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
 
-         # 감정 ID 긍정/부정 구분 필터 설정
+        # 감정 ID 긍정/부정 구분 필터 설정
         positive_emotion_ids = [1, 2, 3]
         negative_emotion_ids = [4, 5, 6, 7, 8, 9, 10, 11, 12]
         emotion_filter = Record.emotionCategoryId.in_(

--- a/services/challenge/detail.py
+++ b/services/challenge/detail.py
@@ -1,6 +1,8 @@
 from sqlalchemy.orm import Session
 from typing import List
-from datetime import timedelta
+from datetime import datetime, timedelta
+from fastapi import HTTPException
+
 from models.challenge import ChallengeParticipant
 from schemas.challenge import ChallengeDetailRead, ChallengeMemberRead
 from services.challenge.validate import ChallengeValidateService
@@ -11,29 +13,36 @@ class ChallengeDetailService:
     @staticmethod
     def read_participants(db: Session, challenge_id: int) -> List[ChallengeParticipant]:
         return db.query(ChallengeParticipant).filter_by(challengeId=challenge_id).all()
-        
+
     @staticmethod
     def read_challenge_detail(db: Session, challenge_id: int, user_id: int) -> ChallengeDetailRead:
+
+        challenge = ChallengeValidateService.validate_challenge(db, challenge_id) 
+
+        end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
+        today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         
-        challenge = ChallengeValidateService.validate_challenge(db, challenge_id)
-        participants = ChallengeDetailService.read_participants(db, challenge_id)  
-        participants_contribution = ChallengeCalculateService.participants_rate(db, challenge, participants) 
-        team_progress = ChallengeCalculateService.team_rate(challenge, participants_contribution)  
-        
+        if end_date <= today_date:
+            raise HTTPException(status_code=404, detail="챌린지 기간이 종료되었거나 존재하지 않습니다.")
+
+        participants = ChallengeDetailService.read_participants(db, challenge_id)
+        participants_contribution = ChallengeCalculateService.participants_rate(db, challenge, participants)
+        team_progress = ChallengeCalculateService.team_rate(challenge, participants_contribution)
+
         return ChallengeDetailRead(
             challengeId=challenge.challengeId,
             name=challenge.name,
             publicityType=challenge.publicityType,
             challengeType=challenge.challengeType,
-            endDate=(challenge.createdDate + timedelta(days=6)),
+            endDate=end_date,
             goalCount=challenge.goalCount,
             guineaFeedCurrent=team_progress.guineaFeedCount,
             teamProgressRate=team_progress.teamProgressRate,
-                participantsInfo=[
-                    ChallengeMemberRead(
-                        userId=participant.userId,
-                        isHost=participant.isHost,
-                        contributionRate=participant.contributionRate
-                    ) for participant in participants_contribution
-                ]
-            )
+            participantsInfo=[
+                ChallengeMemberRead(
+                    userId=participant.userId,
+                    isHost=participant.isHost,
+                    contributionRate=participant.contributionRate
+                ) for participant in participants_contribution
+            ]
+        )

--- a/services/challenge/read.py
+++ b/services/challenge/read.py
@@ -9,7 +9,6 @@ from schemas.challenge import ChallengeListRead, ChallengeRead
 
 class ChallengeReadService:
 
-    # 목록 조회
     @staticmethod 
     def read_challenges_list(db: Session) -> List[ChallengeListRead]:
 
@@ -47,7 +46,6 @@ class ChallengeReadService:
 
         return challenges_list
 
-    # 단건 조회
     @staticmethod
     def read_challenge(db: Session, challenge_id: int) -> ChallengeRead:
 
@@ -83,7 +81,6 @@ class ChallengeReadService:
             participantCount=participants_count,
         )
 
-    # 검색 조회
     @staticmethod
     def search_challenge(db: Session, query: str) -> List[ChallengeListRead]:
 
@@ -122,7 +119,6 @@ class ChallengeReadService:
 
         return challenges_list
 
-    # 현재 참여중인 챌린지 아이디 조회 (기간 내)
     @staticmethod
     def read_current_challenge(db: Session, user_id: int) -> int:
 

--- a/services/challenge/read.py
+++ b/services/challenge/read.py
@@ -1,58 +1,71 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, text
 from datetime import datetime, timedelta
 from fastapi import HTTPException
 from typing import List
 
 from models.challenge import Challenge, ChallengeParticipant
 from schemas.challenge import ChallengeListRead, ChallengeRead
-from services.challenge.validate import ChallengeValidateService
 
 class ChallengeReadService:
-    
+
+    # 목록 조회
+    @staticmethod 
     def read_challenges_list(db: Session) -> List[ChallengeListRead]:
 
-        current_date = datetime.now()
+        today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = func.date_add(func.date(Challenge.createdDate), text('INTERVAL 7 DAY'))
 
-        # 모든 챌린지 정보 + 해당 챌린지 참여자 수 조회
+        # 유효기간 내의 모든 챌린지 정보 + 해당 챌린지 참여자 수 조회 쿼리
         results = (
             db.query(
                 Challenge,
                 func.count(ChallengeParticipant.userId).label("participant_count"),
             )
             .outerjoin(ChallengeParticipant, Challenge.challengeId == ChallengeParticipant.challengeId)
+            .filter(
+                end_date > today_date
+            )
             .group_by(Challenge.challengeId)
             .all()
         )
 
-        # 기간이 유효한 챌린지만 필터링하여 리스트에 추가
         challenges_list = []
         for challenge, participants_count in results:
-            end_date = challenge.createdDate + timedelta(days=6)  
-            if end_date >= current_date:
-                challenges_list.append(
-                    ChallengeListRead(
-                        challengeId=challenge.challengeId,
-                        name=challenge.name,
-                        publicityType=challenge.publicityType,
-                        challengeType=challenge.challengeType,
-                        endDate=end_date,
-                        goalCount=challenge.goalCount,
-                        participantCount=participants_count,
-                    )
+            end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
+            challenges_list.append(
+                ChallengeListRead(
+                    challengeId=challenge.challengeId,
+                    name=challenge.name,
+                    publicityType=challenge.publicityType,
+                    challengeType=challenge.challengeType,
+                    endDate=end_date,
+                    goalCount=challenge.goalCount,
+                    participantCount=participants_count,
                 )
+            )
 
         return challenges_list
 
+    # 단건 조회
     @staticmethod
     def read_challenge(db: Session, challenge_id: int) -> ChallengeRead:
 
-        current_date = datetime.now()
-        challenge = ChallengeValidateService.validate_challenge(db, challenge_id)
+        today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = func.date_add(func.date(Challenge.createdDate), text('INTERVAL 7 DAY'))
 
-        end_date = challenge.createdDate + timedelta(days=6) 
-        if end_date < current_date:
-            raise HTTPException(status_code=400, detail="챌린지 기간이 종료되었습니다.")
+        challenge = (
+            db.query(Challenge)
+            .filter(
+                Challenge.challengeId == challenge_id,
+                end_date > today_date
+            )
+            .first()
+        )
+        if not challenge:
+            raise HTTPException(status_code=400, detail="챌린지 기간이 종료되었거나 존재하지 않습니다.")
+
+        end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
 
         participants_count = (
             db.query(ChallengeParticipant)
@@ -70,12 +83,14 @@ class ChallengeReadService:
             participantCount=participants_count,
         )
 
+    # 검색 조회
     @staticmethod
     def search_challenge(db: Session, query: str) -> List[ChallengeListRead]:
 
-        current_date = datetime.now()
-
-        # 검색어 포함 + 챌린지 기간 유효한 챌린지와 참여자 수 조회 쿼리 실행
+        today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = func.date_add(func.date(Challenge.createdDate), text('INTERVAL 7 DAY'))
+        
+         # 검색어 포함 + 기간 유효한 챌린지 + 참여자 수 조회 쿼리
         results = (
             db.query(
                 Challenge,
@@ -84,42 +99,43 @@ class ChallengeReadService:
             .outerjoin(ChallengeParticipant, Challenge.challengeId == ChallengeParticipant.challengeId)
             .filter(
                 Challenge.name.ilike(f"%{query}%"),
-                (Challenge.createdDate + timedelta(days=7)) > current_date,
+                end_date > today_date
             )
             .group_by(Challenge.challengeId)
             .all()
         )
 
-        # 검색 결과 시 유효한 챌린지를 리스트에 추가
         challenges_list = []
         for challenge, participants_count in results:
+            end_date = challenge.createdDate.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
             challenges_list.append(
                 ChallengeListRead(
                     challengeId=challenge.challengeId,
                     name=challenge.name,
                     challengeType=challenge.challengeType,
                     publicityType=challenge.publicityType,
-                    endDate=(challenge.createdDate + timedelta(days=7)),
-                    goalCount = challenge.goalCount,
+                    endDate=end_date,
+                    goalCount=challenge.goalCount,
                     participantCount=participants_count,
                 )
             )
 
         return challenges_list
 
-
+    # 현재 참여중인 챌린지 아이디 조회 (기간 내)
     @staticmethod
     def read_current_challenge(db: Session, user_id: int) -> int:
-        current_date = datetime.now()
 
-        # 현재 참여 중인 챌린지 조회 (기간 내)
+        today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = func.date_add(func.date(Challenge.createdDate), text('INTERVAL 7 DAY'))
+
         participant = (
             db.query(ChallengeParticipant)
             .join(Challenge)
             .filter(
                 ChallengeParticipant.userId == user_id,
-                Challenge.createdDate <= current_date,
-                Challenge.createdDate + timedelta(days=6) >= current_date,
+                Challenge.createdDate <= datetime.now(),
+                end_date > today_date
             )
             .first()
         )


### PR DESCRIPTION
## #️⃣ Issue Number<!--- ex) #이슈번호, #이슈번호 -->
#29 
## 📝 요약(Summary)<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 챌린지는 생성일 포함 7일째까지 유효 -> 마감일을 8일째 되는 날 자정으로 설정함
       ◦ ex) 2025-08-05에 생성된 챌린지이면 7일 째 되는 날인 2025-08-11까지 유효하고, 2025-08-12 자정이 되면 즉시 종료
- SQL 쿼리와 Python 코드 양쪽에서 마감일 계산 방식을 일치 시켜 중복 검증 효과 및 안정성 강화
       ◦ 파이썬 코드에서의 마감일 계산 목적 : 클라이언트에 보여줄 응답 데이터 용도
       ◦  SQL 쿼리 내 마감일 계산 목적 :  DB에서 조건에 맞는 데이터만 필터링 목적
## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)## 💬 공유사항 to 리뷰어<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
